### PR TITLE
chore(ci): add package and claude-shared update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      download-package-updates:
+        description: 'Download updated-csproj-files artifact before building'
+        type: boolean
+        required: false
+        default: false
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+
+  build:
+    runs-on:
+      group: fmfx-gha-runners-linux-static-ip
+
+    permissions:
+      contents: write
+      packages: write
+      actions: read
+
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-gha-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.FMFX_CI_APP_ID }}
+          private-key: ${{ secrets.FMFX_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ steps.generate-gha-token.outputs.token }}
+          ref: ${{ github.head_ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+          source-url: https://nuget.pkg.github.com/FreemarketFX/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.ADMIN_READ_NUGET_TOKEN }}
+
+      - name: Restore NuGet cache
+        uses: actions/cache/restore@v5
+        id: cache-restore
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-
+
+      - name: Download updated csproj files
+        if: inputs.download-package-updates
+        uses: actions/download-artifact@v8
+        with:
+          name: updated-csproj-files
+
+      - name: Build solution
+        working-directory: src
+        run: dotnet build Skoruba.Duende.IdentityServer.Admin.sln --configuration Release --verbosity quiet
+
+      - name: Save NuGet cache (main only)
+        if: github.ref == 'refs/heads/main' && steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/update-claude-shared.yml
+++ b/.github/workflows/update-claude-shared.yml
@@ -1,0 +1,34 @@
+name: Update claude-shared
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [claude-shared-updated]
+  schedule:
+    - cron: "0 7 * * 1-5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-claude-shared:
+    permissions:
+      contents: write
+      actions: read
+    uses: FreemarketFX/gha-shared-workflows/.github/workflows/update-claude-shared.yml@main
+    secrets: inherit
+
+  notify_slack:
+    if: always() && github.ref == 'refs/heads/main'
+    needs: [update-claude-shared]
+    permissions:
+      actions: read
+    uses: FreemarketFX/gha-shared-workflows/.github/workflows/notify-slack.yml@main
+    secrets:
+      slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK_URL_PLATFORM_RELEASES }}
+    with:
+      jobResults: ${{ toJSON(needs.*.result) }}

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -1,0 +1,48 @@
+name: Update Duende.IdentityServer.Admin Packages
+
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 0 * * *"
+
+jobs:
+  update_packages:
+    permissions:
+      contents: write
+      packages: write
+      actions: read
+    uses: FreemarketFX/gha-shared-workflows/.github/workflows/dotnet-outdated.yml@main
+    secrets: inherit
+
+  build:
+    needs: update_packages
+    permissions:
+      contents: write
+      packages: write
+      actions: read
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+    with:
+      download-package-updates: true
+
+  commit_package_updates:
+    needs: build
+    permissions:
+      contents: write
+      packages: write
+      actions: read
+    uses: FreemarketFX/gha-shared-workflows/.github/workflows/commit-package-updates.yml@main
+    secrets: inherit
+
+  notify_slack:
+    if: always() && github.ref == 'refs/heads/main'
+    needs: [update_packages, build, commit_package_updates]
+    permissions:
+      actions: read
+    uses: FreemarketFX/gha-shared-workflows/.github/workflows/notify-slack.yml@main
+    secrets:
+      slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK_URL_PLATFORM_RELEASES }}
+    with:
+      jobResults: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
## Summary
- Adds `ci.yml` — reusable build workflow (.NET 10, builds `src/Skoruba.Duende.IdentityServer.Admin.sln`). Also runs on PR/push to main.
- Adds `update-packages.yml` — daily 00:15 cron: `dotnet-outdated` → `ci.yml` build verification → `commit-package-updates` → Slack.
- Adds `update-claude-shared.yml` — weekday 07:00 sync via shared workflow + `repository_dispatch` trigger.
- Slack notifications routed to `SLACK_WEBHOOK_URL_PLATFORM_RELEASES`.

Templated from `ClientActions` and adapted to this repo's layout (`.sln` under `src/`, no migrations, no `global.json`).

## Test plan
- [ ] Run `update-claude-shared` via `workflow_dispatch` and confirm green
- [ ] Run `update-packages` via `workflow_dispatch` and confirm chain completes
- [ ] Confirm Slack posts to the platform-releases channel
- [ ] Confirm `fmfx-gha-runners-linux-static-ip` runner group is accessible to this repo

Co-Authored-By: Claude <noreply@anthropic.com>